### PR TITLE
feat: @SQLDelete와 @where를 사용하여 게시글 삭제 시 update 문을 실행하고, 조회 시 조건을 검

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+core-module/src/main/resources/application-*.properties

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'java-library'
+    apply plugin: 'java'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
 

--- a/core-module/build.gradle
+++ b/core-module/build.gradle
@@ -1,5 +1,15 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web:3.0.4'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
+    implementation group: 'org.javassist', name: 'javassist', version: '3.15.0-GA'
 }
 
 bootJar {

--- a/core-module/src/main/java/com/example/coremodule/common/Status.java
+++ b/core-module/src/main/java/com/example/coremodule/common/Status.java
@@ -1,0 +1,9 @@
+package com.example.coremodule.common;
+
+public class Status {
+
+    public enum Post {
+        ALIVE,
+        DELETED
+    }
+}

--- a/core-module/src/main/java/com/example/coremodule/post/domain/Post.java
+++ b/core-module/src/main/java/com/example/coremodule/post/domain/Post.java
@@ -1,0 +1,42 @@
+package com.example.coremodule.post.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@Entity
+@DynamicUpdate          // 변경된 컬럼만 update
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String tag;
+
+    @Column(nullable = false)
+    private String image;
+
+    @Builder
+    public Post(String title, String content, String tag, String image) {
+        this.title = title;
+        this.content = content;
+        this.tag = tag;
+        this.image = image;
+    }
+}

--- a/core-module/src/main/java/com/example/coremodule/post/domain/Post.java
+++ b/core-module/src/main/java/com/example/coremodule/post/domain/Post.java
@@ -7,10 +7,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Entity
 @DynamicUpdate          // 변경된 컬럼만 update
+@Where(clause = "status = 'ALIVE'")
+@SQLDelete(sql = "UPDATE post SET status = 'DELETE' WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 

--- a/core-module/src/main/java/com/example/coremodule/post/domain/Post.java
+++ b/core-module/src/main/java/com/example/coremodule/post/domain/Post.java
@@ -1,5 +1,6 @@
 package com.example.coremodule.post.domain;
 
+import com.example.coremodule.common.Status;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,11 +33,16 @@ public class Post {
     @Column(nullable = false)
     private String image;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status.Post status;
+
     @Builder
-    public Post(String title, String content, String tag, String image) {
+    public Post(String title, String content, String tag, String image, Status.Post status) {
         this.title = title;
         this.content = content;
         this.tag = tag;
         this.image = image;
+        this.status = status;
     }
 }

--- a/core-module/src/main/java/com/example/coremodule/post/domain/PostRepository.java
+++ b/core-module/src/main/java/com/example/coremodule/post/domain/PostRepository.java
@@ -1,0 +1,6 @@
+package com.example.coremodule.post.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/core-module/src/main/resources/application.properties
+++ b/core-module/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+spring.config.import=classpath:application-dev.properties


### PR DESCRIPTION
### 작업 내용
- [x] post 엔티티에 status 컬럼을 추가
- [x] 사용자가 커뮤니티 게시글 삭제 시 DB에서 데이터를 삭제하지 않고 status가 deleted 상태로 update되게 함
- [x] 게시글 조회 시 status가 alive 상태인 데이터만 가져오게 함
<br><br>
- resolved #3

### 테스트 결과
테스트 결과 이상 없음.